### PR TITLE
Add filtering on backend side

### DIFF
--- a/backend/src/main/kotlin/pl/edu/agh/backend/search/AdditionalInfo.kt
+++ b/backend/src/main/kotlin/pl/edu/agh/backend/search/AdditionalInfo.kt
@@ -1,3 +1,3 @@
 package pl.edu.agh.backend.search
 
-class AdditionalInfo(val disabledFormats : List<String> = emptyList())
+class AdditionalInfo(var enabledFormats : List<String> = emptyList())

--- a/backend/src/main/kotlin/pl/edu/agh/backend/search/MicroserviceCommunicationService.kt
+++ b/backend/src/main/kotlin/pl/edu/agh/backend/search/MicroserviceCommunicationService.kt
@@ -9,14 +9,10 @@ import java.io.File
 @Service
 class MicroserviceCommunicationService {
 
-    val servicesNames : Map<String, String> = mapOf(
-            "text-search" to "80",
-            "odt-search" to "8182"
-    )
-
+    val serviceMap : ServiceMap = ServiceMap()
     val restTemplate: RestTemplate = RestTemplateBuilder().build()
 
-    fun getResponse(phrase : String, rootPath : String): Map<String, Any> {
+    fun getResponse(phrase : String, rootPath : String, enabledFormats : List<String>): Map<String, Any> {
 
         if(!fileExists(rootPath)){
             return mapOf("backend" to ErrorResponse(path = rootPath, errors = listOf("The given path does not exists.")) as Any)
@@ -24,8 +20,10 @@ class MicroserviceCommunicationService {
 
         val results = mutableMapOf<String, Any>()
 
-        servicesNames.forEach {
-            results.put(it.key, restTemplate.getForObject("http://${it.key}:${it.value}/search?phrase={phrase}&rootPath={path}", phrase, rootPath))
+        println(enabledFormats)
+
+        serviceMap.filterServices(enabledFormats).forEach {
+            results[it.key] = restTemplate.getForObject("http://${it.key}:${it.value}/search?phrase={phrase}&rootPath={path}", phrase, rootPath)
         }
 
         return results

--- a/backend/src/main/kotlin/pl/edu/agh/backend/search/SearchController.kt
+++ b/backend/src/main/kotlin/pl/edu/agh/backend/search/SearchController.kt
@@ -15,8 +15,7 @@ class SearchController @Autowired constructor(val communicationService : Microse
     @CrossOrigin
     @GetMapping("/search")
     fun results(request : FrontendRequest) : Map<String, Any> {
-        return communicationService.getResponse(request.phrase, request.rootPath)
-
+        return communicationService.getResponse(request.phrase, request.rootPath, request.additionalInfo.enabledFormats)
     }
 
 }

--- a/backend/src/main/kotlin/pl/edu/agh/backend/search/ServiceMap.kt
+++ b/backend/src/main/kotlin/pl/edu/agh/backend/search/ServiceMap.kt
@@ -1,0 +1,12 @@
+package pl.edu.agh.backend.search
+
+class ServiceMap {
+
+        private val servicesNames : Map<String, String> = mapOf(
+                "text-search" to "80",
+                "odt-search" to "8182"
+        )
+
+        fun filterServices(enabledFormats: List<String>) : Map<String, String> = servicesNames.filter { it.key in enabledFormats }
+
+}


### PR DESCRIPTION
Now, backend accepts an additional parameter - enabled formats.
Example request:
`http://localhost:8080/search?rootPath=/app/files&phrase=bells&additionalInfo.enabledFormats=text-search`