### PR TITLE
Docker caches

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,14 +1,15 @@
 FROM gradle:7.4.1-jdk11-alpine AS build
-COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
-RUN gradle build --no-daemon
+
+COPY build.gradle.kts settings.gradle.kts ./
+RUN gradle dependencies --refresh-dependencies -i
+
+COPY . .
+RUN gradle build --no-daemon -i
 
 FROM openjdk:11-jre-slim
-
-EXPOSE 8080
-
-RUN mkdir /app
-
+WORKDIR /app
 COPY --from=build /home/gradle/src/build/libs/*.jar /app/backend.jar
 
+EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "/app/backend.jar"]

--- a/odt-search/Dockerfile
+++ b/odt-search/Dockerfile
@@ -1,12 +1,15 @@
 FROM maven:3.6.0-jdk-11-slim AS build
-COPY src /home/app/src
-COPY pom.xml /home/app
-RUN mvn -f /home/app/pom.xml clean package
+WORKDIR /home/app
 
-#
-# Package stage
-#
+COPY pom.xml .
+RUN mvn package
+
+COPY src .
+RUN mvn package
+
 FROM openjdk:11-jre-slim
-COPY --from=build /home/app/target/odt-search-1.0-SNAPSHOT.jar /usr/local/lib/odt-search.jar
+WORKDIR /app
+COPY --from=build /home/app/target/*.jar /app/odt-search.jar
+
 EXPOSE 8182
-ENTRYPOINT ["java","-jar","/usr/local/lib/odt-search.jar"]
+ENTRYPOINT ["java", "-jar", "/app/odt-search.jar"]

--- a/odt-search/Dockerfile
+++ b/odt-search/Dockerfile
@@ -4,12 +4,12 @@ WORKDIR /home/app
 COPY pom.xml .
 RUN mvn package
 
-COPY src .
+COPY . .
 RUN mvn package
 
 FROM openjdk:11-jre-slim
 WORKDIR /app
-COPY --from=build /home/app/target/*.jar /app/odt-search.jar
+COPY --from=build /home/app/target/odt-search*.jar /app/odt-search.jar
 
 EXPOSE 8182
 ENTRYPOINT ["java", "-jar", "/app/odt-search.jar"]


### PR DESCRIPTION
Updated docker files to take advantage of dependency cacheing.
While this will have some impact on image size, it will reduce build time.
This is especially visible in odt-search. 